### PR TITLE
Store a strong reference to the Add button

### DIFF
--- a/Pod/Classes/VOKMultiImagePicker.h
+++ b/Pod/Classes/VOKMultiImagePicker.h
@@ -55,7 +55,7 @@ NS_ENUM(NSInteger, VOKMultiImagePickerStartPosition){
  *  The button the user will select to finish selecting assets.
  *  This button can be customized.
  */
-@property (nonatomic, weak, readonly) UIButton *addItemsButton;
+@property (nonatomic, readonly) UIButton *addItemsButton;
 
 /**
  *  The media type of assets to display. All other assets will not


### PR DESCRIPTION
The add button is created in code, and had been a weak reference. This worked fine on iPhone 5, for some reason, but on 6, the button never appears because it's released before it can be displayed.

@vokalinteractive/ios-developers want a rulllll quick one?
