### PR TITLE
Move cell init into a common setup

### DIFF
--- a/Pod/Classes/Views/VOKAssetCollectionsCell.m
+++ b/Pod/Classes/Views/VOKAssetCollectionsCell.m
@@ -39,6 +39,13 @@ static CGFloat const VOKAssetCollectionCellImageMargin = 5.0f;
     return self;
 }
 
+- (instancetype)initWithFrame:(CGRect)frame {
+    if (self = [super initWithFrame:frame]) {
+        [self commonSetup];
+    }
+    return self;
+}
+
 - (void)commonSetup
 {
     self.accessoryType = UITableViewCellAccessoryDisclosureIndicator;


### PR DESCRIPTION
Related to #11: the disclosure indicator wasn't being shown because the `init` method was never called; `initWithStyle:reuseIdentifier` was. I moved the init logic into a common setup method and call that from all four init methods.

@vokalinteractive/ios-developers anybody around for a quickie?
