### PR TITLE
Update VOKMultiImagePicker-iOS.podspec

### DIFF
--- a/VOKMultiImagePicker-iOS.podspec
+++ b/VOKMultiImagePicker-iOS.podspec
@@ -10,7 +10,7 @@
 Pod::Spec.new do |s|
   s.name             = "VOKMultiImagePicker-iOS"
   s.version          = "0.1.0"
-  s.summary          = "A multiple image picker using Photos framework.”
+  s.summary          = "A multiple image picker using Photos framework."
   s.description      = "A customizable library for selecting assets from the built in Photos app using the Photos framework."
   s.homepage         = "https://github.com/vokalinteractive/VOKMultiImagePicker-iOS"
   s.license          = 'MIT'


### PR DESCRIPTION
Removed ligature quote which was causing CocoaPod 0.36 install error.